### PR TITLE
Add noop delivery provider implementation

### DIFF
--- a/src/ArquivoMate2.Infrastructure/Configuration/DeliveryProvider/DeliveryProviderType.cs
+++ b/src/ArquivoMate2.Infrastructure/Configuration/DeliveryProvider/DeliveryProviderType.cs
@@ -9,6 +9,7 @@ namespace ArquivoMate2.Infrastructure.Configuration.DeliveryProvider
 {
     public enum DeliveryProviderType
     {
+        Noop,
         S3,
         Bunny,
         Cloudfront
@@ -68,6 +69,7 @@ namespace ArquivoMate2.Infrastructure.Configuration.DeliveryProvider
 
             return type switch
             {
+                DeliveryProviderType.Noop => new DeliveryProviderSettings { Type = DeliveryProviderType.Noop },
                 DeliveryProviderType.S3 => section.GetSection("Args").Get<S3DeliveryProviderSettings>()
                                         ?? throw new InvalidOperationException("S3DeliveryProviderSettings fehlt."),
                 DeliveryProviderType.Bunny => section.GetSection("Args").Get<BunnyDeliveryProviderSettings>()

--- a/src/ArquivoMate2.Infrastructure/Configuration/DependencyInjectionConfiguration.cs
+++ b/src/ArquivoMate2.Infrastructure/Configuration/DependencyInjectionConfiguration.cs
@@ -256,6 +256,9 @@ namespace ArquivoMate2.Infrastructure.Configuration
 
             switch (deliverySettings)
             {
+                case DeliveryProviderSettings noop when noop.Type == DeliveryProviderType.Noop:
+                    services.AddScoped<IDeliveryProvider, NoopDeliveryProvider>();
+                    break;
                 case S3DeliveryProviderSettings s3:
                     services.Configure<S3DeliveryProviderSettings>(config.GetSection("DeliveryProvider").GetSection("Args"));
                     services.AddScoped<IDeliveryProvider, S3DeliveryProvider>();

--- a/src/ArquivoMate2.Infrastructure/Services/DeliveryProvider/NoopDeliveryProvider.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/DeliveryProvider/NoopDeliveryProvider.cs
@@ -1,0 +1,13 @@
+using ArquivoMate2.Application.Interfaces;
+using System.Threading.Tasks;
+
+namespace ArquivoMate2.Infrastructure.Services.DeliveryProvider
+{
+    public class NoopDeliveryProvider : IDeliveryProvider
+    {
+        public Task<string> GetAccessUrl(string fullPath)
+        {
+            return Task.FromResult(fullPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a Noop delivery provider option so encrypted deliveries can skip external providers
- wire the Noop provider into dependency injection and configuration
- implement a simple NoopDeliveryProvider that returns the provided path unchanged

## Testing
- dotnet build ArquivoMate2.sln *(fails: Microsoft.Build.Exceptions.InternalLoggerException due to TerminalLogger argument range)*

------
https://chatgpt.com/codex/tasks/task_e_68deac6c20708324ae37af4f6fa3b227