### PR TITLE
Add maintenance endpoint to export document encryption keys

### DIFF
--- a/src/ArquivoMate2.API/Controllers/MaintenanceController.cs
+++ b/src/ArquivoMate2.API/Controllers/MaintenanceController.cs
@@ -1,0 +1,86 @@
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using ArquivoMate2.API.Filters;
+using ArquivoMate2.Domain.Document;
+using Marten;
+using Marten.Events;
+using Marten.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ArquivoMate2.API.Controllers;
+
+[ApiController]
+[Route("api/maintenance")]
+[ServiceFilter(typeof(ApiKeyAuthorizationFilter))]
+public class MaintenanceController : ControllerBase
+{
+    private readonly IQuerySession _querySession;
+
+    public MaintenanceController(IQuerySession querySession)
+    {
+        _querySession = querySession;
+    }
+
+    /// <summary>
+    /// Creates a ZIP archive containing all DocumentEncryptionKeysAdded events for backup purposes.
+    /// </summary>
+    [HttpGet("document-encryption-keys")] 
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DownloadDocumentEncryptionKeysAsync(CancellationToken cancellationToken)
+    {
+        var events = await _querySession.Events
+            .QueryAllRawEvents()
+            .Where(e => e.EventTypeName == nameof(DocumentEncryptionKeysAdded)
+                        || e.EventTypeName == typeof(DocumentEncryptionKeysAdded).FullName)
+            .OrderBy(e => e.Sequence)
+            .ToListAsync(cancellationToken);
+
+        var payload = events
+            .Select(e => new
+            {
+                Event = e,
+                Data = e.Data as DocumentEncryptionKeysAdded
+            })
+            .Where(e => e.Data is not null)
+            .Select(e => new DocumentEncryptionKeysBackupItem
+            {
+                StreamId = e.Event.StreamId,
+                EventId = e.Event.Id,
+                Sequence = e.Event.Sequence,
+                Timestamp = e.Event.Timestamp.UtcDateTime,
+                Event = e.Data!
+            })
+            .ToList();
+
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+
+        using var archiveStream = new MemoryStream();
+        using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("document-encryption-keys.json", CompressionLevel.Optimal);
+            using var entryStream = entry.Open();
+            using var writer = new StreamWriter(entryStream, new UTF8Encoding(false));
+            await writer.WriteAsync(json);
+            await writer.FlushAsync();
+        }
+
+        archiveStream.Position = 0;
+        var fileName = $"document-encryption-keys-backup-{DateTime.UtcNow:yyyyMMddHHmmss}.zip";
+        return File(archiveStream.ToArray(), "application/zip", fileName);
+    }
+
+    private sealed class DocumentEncryptionKeysBackupItem
+    {
+        public Guid StreamId { get; init; }
+        public Guid EventId { get; init; }
+        public long Sequence { get; init; }
+        public DateTime Timestamp { get; init; }
+        public DocumentEncryptionKeysAdded Event { get; init; } = default!;
+    }
+}

--- a/src/ArquivoMate2.API/Filters/ApiKeyAuthorizationFilter.cs
+++ b/src/ArquivoMate2.API/Filters/ApiKeyAuthorizationFilter.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using ArquivoMate2.Domain.Users;
+using Marten;
+using Marten.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace ArquivoMate2.API.Filters;
+
+/// <summary>
+/// Ensures that incoming requests contain a valid API key issued to a user profile.
+/// </summary>
+public class ApiKeyAuthorizationFilter : IAsyncActionFilter
+{
+    private readonly IQuerySession _querySession;
+    private const string ApiKeyHeaderName = "X-Api-Key";
+
+    public ApiKeyAuthorizationFilter(IQuerySession querySession)
+    {
+        _querySession = querySession;
+    }
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        var httpContext = context.HttpContext;
+        if (!httpContext.Request.Headers.TryGetValue(ApiKeyHeaderName, out var headerValues))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        var providedKey = headerValues.FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(providedKey))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        var user = await _querySession.Query<UserProfile>()
+            .FirstOrDefaultAsync(x => x.ApiKey == providedKey, httpContext.RequestAborted);
+
+        if (user is null)
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        httpContext.Items[nameof(UserProfile)] = user;
+        await next();
+    }
+}

--- a/src/ArquivoMate2.API/Program.cs
+++ b/src/ArquivoMate2.API/Program.cs
@@ -1,3 +1,4 @@
+using ArquivoMate2.API.Filters;
 using ArquivoMate2.API.Hubs;
 using ArquivoMate2.API.Notifications;
 using ArquivoMate2.Application.Handlers;
@@ -72,6 +73,7 @@ namespace ArquivoMate2.API
               });
 
             builder.Services.AddControllers();
+            builder.Services.AddScoped<ApiKeyAuthorizationFilter>();
             builder.Services.AddInfrastructure(builder.Configuration);
             builder.Services.AddHttpContextAccessor();
 


### PR DESCRIPTION
## Summary
- add an API-key protected maintenance controller
- implement export endpoint that bundles all DocumentEncryptionKeysAdded events into a zip backup
- register reusable API key authorization filter for maintenance requests

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build ArquivoMate2.sln` *(fails: NuGet restore blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68dee64996e88324a6772a08a8c469c7