### PR TITLE
Bind PartyInfo entries to user scope

### DIFF
--- a/src/ArquivoMate2.Application/Models/PartyInfo.cs
+++ b/src/ArquivoMate2.Application/Models/PartyInfo.cs
@@ -9,6 +9,7 @@ namespace ArquivoMate2.Application.Models
 
     public class PartyInfo
     {
+        public string UserId { get; set; } = string.Empty;
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
         public string CompanyName { get; set; } = string.Empty;

--- a/src/ArquivoMate2.Application/Models/PartyInfo.cs
+++ b/src/ArquivoMate2.Application/Models/PartyInfo.cs
@@ -9,7 +9,7 @@ namespace ArquivoMate2.Application.Models
 
     public class PartyInfo
     {
-        public string UserId { get; set; } = string.Empty;
+        public required string UserId { get; init; }
         public string FirstName { get; set; } = string.Empty;
         public string LastName { get; set; } = string.Empty;
         public string CompanyName { get; set; } = string.Empty;

--- a/src/ArquivoMate2.Infrastructure/Configuration/DependencyInjectionConfiguration.cs
+++ b/src/ArquivoMate2.Infrastructure/Configuration/DependencyInjectionConfiguration.cs
@@ -101,7 +101,8 @@ namespace ArquivoMate2.Infrastructure.Configuration
                     typeof(DocumentLanguageDetected) // RESTORED
                 });
 
-                options.Schema.For<PartyInfo>();
+                options.Schema.For<PartyInfo>()
+                    .Index(x => x.UserId);
                 options.Schema.For<EmailSettings>()
                     .Index(x => x.UserId)
                     .Index(x => x.IsActive);

--- a/src/ArquivoMate2.Infrastructure/Mapping/DocumentMapping.cs
+++ b/src/ArquivoMate2.Infrastructure/Mapping/DocumentMapping.cs
@@ -80,13 +80,13 @@ namespace ArquivoMate2.Infrastructure.Mapping
         }
 
         public PartyDto? Resolve(DocumentView source, DocumentDto destination, Guid? sourceMember, PartyDto? destMember, ResolutionContext context)
-            => ResolveInternal(sourceMember);
+            => ResolveInternal(sourceMember, source.UserId);
 
-        private PartyDto? ResolveInternal(Guid? sourceMember)
+        private PartyDto? ResolveInternal(Guid? sourceMember, string ownerUserId)
         {
             if (!sourceMember.HasValue) return null;
             // synchronous query to load party info
-            var party = _query.Query<PartyInfo>().FirstOrDefault(p => p.Id == sourceMember.Value);
+            var party = _query.Query<PartyInfo>().FirstOrDefault(p => p.Id == sourceMember.Value && p.UserId == ownerUserId);
             if (party == null) return null;
             return new PartyDto
             {
@@ -115,7 +115,7 @@ namespace ArquivoMate2.Infrastructure.Mapping
         public PartyListDto? Resolve(DocumentView source, DocumentListItemDto destination, Guid? sourceMember, PartyListDto? destMember, ResolutionContext context)
         {
             if (!sourceMember.HasValue) return null;
-            var party = _query.Query<PartyInfo>().FirstOrDefault(p => p.Id == sourceMember.Value);
+            var party = _query.Query<PartyInfo>().FirstOrDefault(p => p.Id == sourceMember.Value && p.UserId == source.UserId);
             if (party == null) return null;
             var display = string.IsNullOrWhiteSpace(party.CompanyName)
                 ? string.Join(' ', new[] { party.FirstName, party.LastName }.Where(s => !string.IsNullOrWhiteSpace(s))).Trim()


### PR DESCRIPTION
## Summary
- add a user identifier to PartyInfo and index it in Marten
- scope chatbot party resolution to the processing user when reusing or creating records
- ensure document mapping only resolves party data that belongs to the document owner

## Testing
- dotnet test ArquivoMate2.sln *(fails: Microsoft.Build TerminalLogger ArgumentOutOfRangeException in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2be7de2888324a6cac2bc4a884280