### PR TITLE
Add API endpoints to manage PartyInfo records

### DIFF
--- a/src/ArquivoMate2.API/Controllers/PartiesController.cs
+++ b/src/ArquivoMate2.API/Controllers/PartiesController.cs
@@ -1,0 +1,95 @@
+using ArquivoMate2.Application.Commands.Parties;
+using ArquivoMate2.Application.Queries.Parties;
+using ArquivoMate2.Shared.Models;
+using ArquivoMate2.Shared.Models.Party;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ArquivoMate2.API.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/parties")]
+public class PartiesController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public PartiesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<PartyDto>))]
+    public async Task<IActionResult> List(CancellationToken ct)
+    {
+        var parties = await _mediator.Send(new ListPartiesQuery(), ct);
+        return Ok(parties);
+    }
+
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PartyDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken ct)
+    {
+        var party = await _mediator.Send(new GetPartyQuery(id), ct);
+        if (party is null) return NotFound();
+        return Ok(party);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(PartyDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] CreatePartyRequest request, CancellationToken ct)
+    {
+        if (request is null) return BadRequest();
+
+        var result = await _mediator.Send(new CreatePartyCommand(
+            request.FirstName,
+            request.LastName,
+            request.CompanyName,
+            request.Street,
+            request.HouseNumber,
+            request.PostalCode,
+            request.City), ct);
+
+        return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
+    }
+
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PartyDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdatePartyRequest request, CancellationToken ct)
+    {
+        if (request is null || request.Id == Guid.Empty || request.Id != id)
+        {
+            return BadRequest();
+        }
+
+        var updated = await _mediator.Send(new UpdatePartyCommand(
+            id,
+            request.FirstName,
+            request.LastName,
+            request.CompanyName,
+            request.Street,
+            request.HouseNumber,
+            request.PostalCode,
+            request.City), ct);
+
+        if (updated is null) return NotFound();
+        return Ok(updated);
+    }
+
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken ct)
+    {
+        var success = await _mediator.Send(new DeletePartyCommand(id), ct);
+        if (!success) return NotFound();
+        return NoContent();
+    }
+}

--- a/src/ArquivoMate2.Application/Commands/Parties/CreatePartyCommand.cs
+++ b/src/ArquivoMate2.Application/Commands/Parties/CreatePartyCommand.cs
@@ -1,0 +1,13 @@
+using ArquivoMate2.Shared.Models;
+using MediatR;
+
+namespace ArquivoMate2.Application.Commands.Parties;
+
+public record CreatePartyCommand(
+    string? FirstName,
+    string? LastName,
+    string? CompanyName,
+    string? Street,
+    string? HouseNumber,
+    string? PostalCode,
+    string? City) : IRequest<PartyDto>;

--- a/src/ArquivoMate2.Application/Commands/Parties/DeletePartyCommand.cs
+++ b/src/ArquivoMate2.Application/Commands/Parties/DeletePartyCommand.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ArquivoMate2.Application.Commands.Parties;
+
+public record DeletePartyCommand(Guid Id) : IRequest<bool>;

--- a/src/ArquivoMate2.Application/Commands/Parties/UpdatePartyCommand.cs
+++ b/src/ArquivoMate2.Application/Commands/Parties/UpdatePartyCommand.cs
@@ -1,0 +1,14 @@
+using ArquivoMate2.Shared.Models;
+using MediatR;
+
+namespace ArquivoMate2.Application.Commands.Parties;
+
+public record UpdatePartyCommand(
+    Guid Id,
+    string? FirstName,
+    string? LastName,
+    string? CompanyName,
+    string? Street,
+    string? HouseNumber,
+    string? PostalCode,
+    string? City) : IRequest<PartyDto?>;

--- a/src/ArquivoMate2.Application/Handlers/Parties/CreatePartyHandler.cs
+++ b/src/ArquivoMate2.Application/Handlers/Parties/CreatePartyHandler.cs
@@ -1,0 +1,37 @@
+using ArquivoMate2.Application.Commands.Parties;
+using ArquivoMate2.Application.Models;
+using ArquivoMate2.Shared.Models;
+using Marten;
+using MediatR;
+
+namespace ArquivoMate2.Application.Handlers.Parties;
+
+public class CreatePartyHandler : IRequestHandler<CreatePartyCommand, PartyDto>
+{
+    private readonly IDocumentSession _session;
+
+    public CreatePartyHandler(IDocumentSession session)
+    {
+        _session = session;
+    }
+
+    public async Task<PartyDto> Handle(CreatePartyCommand request, CancellationToken cancellationToken)
+    {
+        var party = new PartyInfo
+        {
+            Id = Guid.NewGuid(),
+            FirstName = request.FirstName?.Trim() ?? string.Empty,
+            LastName = request.LastName?.Trim() ?? string.Empty,
+            CompanyName = request.CompanyName?.Trim() ?? string.Empty,
+            Street = request.Street?.Trim() ?? string.Empty,
+            HouseNumber = request.HouseNumber?.Trim() ?? string.Empty,
+            PostalCode = request.PostalCode?.Trim() ?? string.Empty,
+            City = request.City?.Trim() ?? string.Empty
+        };
+
+        _session.Store(party);
+        await _session.SaveChangesAsync(cancellationToken);
+
+        return party.ToDto();
+    }
+}

--- a/src/ArquivoMate2.Application/Handlers/Parties/DeletePartyHandler.cs
+++ b/src/ArquivoMate2.Application/Handlers/Parties/DeletePartyHandler.cs
@@ -1,0 +1,26 @@
+using ArquivoMate2.Application.Commands.Parties;
+using ArquivoMate2.Application.Models;
+using Marten;
+using MediatR;
+
+namespace ArquivoMate2.Application.Handlers.Parties;
+
+public class DeletePartyHandler : IRequestHandler<DeletePartyCommand, bool>
+{
+    private readonly IDocumentSession _session;
+
+    public DeletePartyHandler(IDocumentSession session)
+    {
+        _session = session;
+    }
+
+    public async Task<bool> Handle(DeletePartyCommand request, CancellationToken cancellationToken)
+    {
+        var party = await _session.LoadAsync<PartyInfo>(request.Id, cancellationToken);
+        if (party is null) return false;
+
+        _session.Delete(party);
+        await _session.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/src/ArquivoMate2.Application/Handlers/Parties/GetPartyHandler.cs
+++ b/src/ArquivoMate2.Application/Handlers/Parties/GetPartyHandler.cs
@@ -1,0 +1,23 @@
+using ArquivoMate2.Application.Models;
+using ArquivoMate2.Application.Queries.Parties;
+using ArquivoMate2.Shared.Models;
+using Marten;
+using MediatR;
+
+namespace ArquivoMate2.Application.Handlers.Parties;
+
+public class GetPartyHandler : IRequestHandler<GetPartyQuery, PartyDto?>
+{
+    private readonly IQuerySession _querySession;
+
+    public GetPartyHandler(IQuerySession querySession)
+    {
+        _querySession = querySession;
+    }
+
+    public async Task<PartyDto?> Handle(GetPartyQuery request, CancellationToken cancellationToken)
+    {
+        var party = await _querySession.LoadAsync<PartyInfo>(request.Id, cancellationToken);
+        return party?.ToDto();
+    }
+}

--- a/src/ArquivoMate2.Application/Handlers/Parties/ListPartiesHandler.cs
+++ b/src/ArquivoMate2.Application/Handlers/Parties/ListPartiesHandler.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ArquivoMate2.Application.Models;
+using ArquivoMate2.Application.Queries.Parties;
+using ArquivoMate2.Shared.Models;
+using Marten;
+using MediatR;
+
+namespace ArquivoMate2.Application.Handlers.Parties;
+
+public class ListPartiesHandler : IRequestHandler<ListPartiesQuery, IReadOnlyCollection<PartyDto>>
+{
+    private readonly IQuerySession _querySession;
+
+    public ListPartiesHandler(IQuerySession querySession)
+    {
+        _querySession = querySession;
+    }
+
+    public async Task<IReadOnlyCollection<PartyDto>> Handle(ListPartiesQuery request, CancellationToken cancellationToken)
+    {
+        var parties = await _querySession
+            .Query<PartyInfo>()
+            .OrderBy(p => p.CompanyName)
+            .ThenBy(p => p.LastName)
+            .ThenBy(p => p.FirstName)
+            .ToListAsync(cancellationToken);
+
+        return parties
+            .Select(p => p.ToDto())
+            .ToList();
+    }
+}

--- a/src/ArquivoMate2.Application/Handlers/Parties/PartyMappingExtensions.cs
+++ b/src/ArquivoMate2.Application/Handlers/Parties/PartyMappingExtensions.cs
@@ -1,0 +1,20 @@
+using ArquivoMate2.Application.Models;
+using ArquivoMate2.Shared.Models;
+
+namespace ArquivoMate2.Application.Handlers.Parties;
+
+internal static class PartyMappingExtensions
+{
+    public static PartyDto ToDto(this PartyInfo party)
+        => new()
+        {
+            Id = party.Id,
+            FirstName = party.FirstName,
+            LastName = party.LastName,
+            CompanyName = party.CompanyName,
+            Street = party.Street,
+            HouseNumber = party.HouseNumber,
+            PostalCode = party.PostalCode,
+            City = party.City
+        };
+}

--- a/src/ArquivoMate2.Application/Handlers/Parties/UpdatePartyHandler.cs
+++ b/src/ArquivoMate2.Application/Handlers/Parties/UpdatePartyHandler.cs
@@ -1,0 +1,36 @@
+using ArquivoMate2.Application.Commands.Parties;
+using ArquivoMate2.Application.Models;
+using ArquivoMate2.Shared.Models;
+using Marten;
+using MediatR;
+
+namespace ArquivoMate2.Application.Handlers.Parties;
+
+public class UpdatePartyHandler : IRequestHandler<UpdatePartyCommand, PartyDto?>
+{
+    private readonly IDocumentSession _session;
+
+    public UpdatePartyHandler(IDocumentSession session)
+    {
+        _session = session;
+    }
+
+    public async Task<PartyDto?> Handle(UpdatePartyCommand request, CancellationToken cancellationToken)
+    {
+        var party = await _session.LoadAsync<PartyInfo>(request.Id, cancellationToken);
+        if (party is null) return null;
+
+        party.FirstName = request.FirstName?.Trim() ?? string.Empty;
+        party.LastName = request.LastName?.Trim() ?? string.Empty;
+        party.CompanyName = request.CompanyName?.Trim() ?? string.Empty;
+        party.Street = request.Street?.Trim() ?? string.Empty;
+        party.HouseNumber = request.HouseNumber?.Trim() ?? string.Empty;
+        party.PostalCode = request.PostalCode?.Trim() ?? string.Empty;
+        party.City = request.City?.Trim() ?? string.Empty;
+
+        _session.Store(party);
+        await _session.SaveChangesAsync(cancellationToken);
+
+        return party.ToDto();
+    }
+}

--- a/src/ArquivoMate2.Application/Queries/Parties/GetPartyQuery.cs
+++ b/src/ArquivoMate2.Application/Queries/Parties/GetPartyQuery.cs
@@ -1,0 +1,6 @@
+using ArquivoMate2.Shared.Models;
+using MediatR;
+
+namespace ArquivoMate2.Application.Queries.Parties;
+
+public record GetPartyQuery(Guid Id) : IRequest<PartyDto?>;

--- a/src/ArquivoMate2.Application/Queries/Parties/ListPartiesQuery.cs
+++ b/src/ArquivoMate2.Application/Queries/Parties/ListPartiesQuery.cs
@@ -1,0 +1,6 @@
+using ArquivoMate2.Shared.Models;
+using MediatR;
+
+namespace ArquivoMate2.Application.Queries.Parties;
+
+public record ListPartiesQuery() : IRequest<IReadOnlyCollection<PartyDto>>;

--- a/src/ArquivoMate2.Shared/Models/Party/CreatePartyRequest.cs
+++ b/src/ArquivoMate2.Shared/Models/Party/CreatePartyRequest.cs
@@ -1,0 +1,12 @@
+namespace ArquivoMate2.Shared.Models.Party;
+
+public class CreatePartyRequest
+{
+    public string? FirstName { get; set; } = string.Empty;
+    public string? LastName { get; set; } = string.Empty;
+    public string? CompanyName { get; set; } = string.Empty;
+    public string? Street { get; set; } = string.Empty;
+    public string? HouseNumber { get; set; } = string.Empty;
+    public string? PostalCode { get; set; } = string.Empty;
+    public string? City { get; set; } = string.Empty;
+}

--- a/src/ArquivoMate2.Shared/Models/Party/CreatePartyRequest.cs
+++ b/src/ArquivoMate2.Shared/Models/Party/CreatePartyRequest.cs
@@ -2,11 +2,11 @@ namespace ArquivoMate2.Shared.Models.Party;
 
 public class CreatePartyRequest
 {
-    public string? FirstName { get; set; } = string.Empty;
-    public string? LastName { get; set; } = string.Empty;
-    public string? CompanyName { get; set; } = string.Empty;
-    public string? Street { get; set; } = string.Empty;
-    public string? HouseNumber { get; set; } = string.Empty;
-    public string? PostalCode { get; set; } = string.Empty;
-    public string? City { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string CompanyName { get; set; } = string.Empty;
+    public string Street { get; set; } = string.Empty;
+    public string HouseNumber { get; set; } = string.Empty;
+    public string PostalCode { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
 }

--- a/src/ArquivoMate2.Shared/Models/Party/UpdatePartyRequest.cs
+++ b/src/ArquivoMate2.Shared/Models/Party/UpdatePartyRequest.cs
@@ -1,0 +1,13 @@
+namespace ArquivoMate2.Shared.Models.Party;
+
+public class UpdatePartyRequest
+{
+    public Guid Id { get; set; }
+    public string? FirstName { get; set; } = string.Empty;
+    public string? LastName { get; set; } = string.Empty;
+    public string? CompanyName { get; set; } = string.Empty;
+    public string? Street { get; set; } = string.Empty;
+    public string? HouseNumber { get; set; } = string.Empty;
+    public string? PostalCode { get; set; } = string.Empty;
+    public string? City { get; set; } = string.Empty;
+}

--- a/src/ArquivoMate2.Shared/Models/Party/UpdatePartyRequest.cs
+++ b/src/ArquivoMate2.Shared/Models/Party/UpdatePartyRequest.cs
@@ -3,11 +3,11 @@ namespace ArquivoMate2.Shared.Models.Party;
 public class UpdatePartyRequest
 {
     public Guid Id { get; set; }
-    public string? FirstName { get; set; } = string.Empty;
-    public string? LastName { get; set; } = string.Empty;
-    public string? CompanyName { get; set; } = string.Empty;
-    public string? Street { get; set; } = string.Empty;
-    public string? HouseNumber { get; set; } = string.Empty;
-    public string? PostalCode { get; set; } = string.Empty;
-    public string? City { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string LastName { get; set; } = string.Empty;
+    public string CompanyName { get; set; } = string.Empty;
+    public string Street { get; set; } = string.Empty;
+    public string HouseNumber { get; set; } = string.Empty;
+    public string PostalCode { get; set; } = string.Empty;
+    public string City { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- add a PartiesController with secured CRUD endpoints for PartyInfo
- implement MediatR commands, queries, and handlers to persist and retrieve PartyInfo documents
- introduce shared request models for creating and updating party details

## Testing
- DOTNET_DISABLE_TERMINAL_LOGGER=1 dotnet test ArquivoMate2.sln *(fails: Microsoft.Build.Exceptions.InternalLoggerException due to TerminalLogger argument out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c1b290bc832485c1cbcc14d820aa