### PR TITLE
Implement custom Meilisearch health check

### DIFF
--- a/src/ArquivoMate2.API/ArquivoMate2.API.csproj
+++ b/src/ArquivoMate2.API/ArquivoMate2.API.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.9" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.1" />
+
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />

--- a/src/ArquivoMate2.API/HealthChecks/MeilisearchHealthCheck.cs
+++ b/src/ArquivoMate2.API/HealthChecks/MeilisearchHealthCheck.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Meilisearch;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace ArquivoMate2.API.HealthChecks;
+
+public class MeilisearchHealthCheck : IHealthCheck
+{
+    private readonly MeilisearchClient _client;
+    private readonly ILogger<MeilisearchHealthCheck> _logger;
+
+    public MeilisearchHealthCheck(MeilisearchClient client, ILogger<MeilisearchHealthCheck> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var healthResponse = await _client.HealthAsync();
+
+            if (healthResponse is bool boolResult)
+            {
+                return boolResult
+                    ? HealthCheckResult.Healthy("Meilisearch is reachable.")
+                    : HealthCheckResult.Unhealthy("Meilisearch reported an unhealthy status.");
+            }
+
+            var statusProperty = healthResponse?.GetType().GetProperty("Status");
+            if (statusProperty?.GetValue(healthResponse) is string status &&
+                status.Equals("available", StringComparison.OrdinalIgnoreCase))
+            {
+                return HealthCheckResult.Healthy("Meilisearch is reachable.");
+            }
+
+            return HealthCheckResult.Unhealthy("Meilisearch did not report a healthy status.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Meilisearch health check failed.");
+            return HealthCheckResult.Unhealthy("Meilisearch is unreachable.", ex);
+        }
+    }
+}

--- a/src/ArquivoMate2.API/Program.cs
+++ b/src/ArquivoMate2.API/Program.cs
@@ -1,5 +1,6 @@
 using ArquivoMate2.API.Filters;
 using ArquivoMate2.API.Hubs;
+using ArquivoMate2.API.HealthChecks;
 using ArquivoMate2.API.Maintenance;
 using ArquivoMate2.Application.Handlers;
 using ArquivoMate2.Application.Interfaces;
@@ -12,10 +13,10 @@ using JasperFx.Core;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
-using Npgsql;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -178,6 +179,10 @@ namespace ArquivoMate2.API
                 options.ResourcesPath = "Localization";
             });
 
+            builder.Services.AddHealthChecks()
+                .AddNpgSql(connectionString, name: "pgsql")
+                .AddCheck<MeilisearchHealthCheck>("meilisearch");
+
             var app = builder.Build();
 
             // Register middleware for producing ProblemDetails on unhandled exceptions
@@ -216,6 +221,8 @@ namespace ArquivoMate2.API
 
             app.MapControllers();
             // controllers are already configured with the ApiResponse wrapper filter
+
+            app.MapHealthChecks("/healthz");
 
             app.MapHangfireDashboard();
 

--- a/src/ArquivoMate2.Infrastructure/Configuration/DependencyInjectionConfiguration.cs
+++ b/src/ArquivoMate2.Infrastructure/Configuration/DependencyInjectionConfiguration.cs
@@ -185,7 +185,15 @@ namespace ArquivoMate2.Infrastructure.Configuration
             services.AddScoped<IFileMetadataService, FileMetadataService>();
             services.AddScoped<IPathService, PathService>();
             services.AddScoped<IThumbnailService, ThumbnailService>();
-            services.AddScoped<MeilisearchClient>(sp => new MeilisearchClient(config["Meilisearch:Url"], "supersecret"));
+            var meilisearchUrl = config["Meilisearch:Url"]
+                ?? throw new InvalidOperationException("Meilisearch URL is not configured.");
+            var meilisearchApiKey = config["Meilisearch:ApiKey"]
+                ?? config["Meilisearch:MasterKey"]
+                ?? config["Meilisearch:Key"]
+                ?? config["MEILI_MASTER_KEY"]
+                ?? "supersecret";
+
+            services.AddScoped<MeilisearchClient>(_ => new MeilisearchClient(meilisearchUrl, meilisearchApiKey));
             services.AddScoped<ISearchClient, SearchClient>();
             services.AddScoped<IDocumentAccessService, DocumentAccessService>();
             services.AddScoped<IAutoShareService, AutoShareService>();


### PR DESCRIPTION
## Summary
- remove the unused AspNetCore.HealthChecks.Meilisearch package reference
- add a custom Meilisearch IHealthCheck that reuses the existing MeilisearchClient
- register the custom Meilisearch health check alongside the PostgreSQL check in Program.cs

## Testing
- TERM=dumb dotnet build src/ArquivoMate2.API/ArquivoMate2.API.csproj *(fails: Unable to reach https://api.nuget.org/v3/index.json via proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e37b261d3c8324bba411116010d16d