### PR TITLE
Fix delivery content type for original files

### DIFF
--- a/src/ArquivoMate2.API/Controllers/DeliveryController.cs
+++ b/src/ArquivoMate2.API/Controllers/DeliveryController.cs
@@ -1,12 +1,16 @@
 using ArquivoMate2.Application.Configuration;
 using ArquivoMate2.Application.Interfaces;
 using ArquivoMate2.Domain.Document;
+using ArquivoMate2.Domain.ValueObjects;
 using ArquivoMate2.Infrastructure.Persistance;
+using EasyCaching.Core;
 using Marten;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
-using EasyCaching.Core;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using ArquivoMate2.Shared.Models; // DocumentArtifact
 
 namespace ArquivoMate2.API.Controllers
@@ -68,58 +72,22 @@ namespace ArquivoMate2.API.Controllers
             };
             if (fullPath == null) return NotFound();
 
-            var artifactWire = artifact.ToWireValue();
-            var cacheKey = $"encfile:{documentId}:{artifactWire}";
+            DocumentEncryptionKeysAdded? encryptionKeys = null;
             if (_settings.Enabled)
             {
-                byte[]? encrypted = null;
-                var cached = await _cache.GetAsync<byte[]>(cacheKey);
-                if (cached.HasValue) encrypted = cached.Value;
-                if (encrypted == null)
-                {
-                    encrypted = await _storage.GetFileAsync(fullPath, ct);
-                    await _cache.SetAsync(cacheKey, encrypted, TimeSpan.FromMinutes(_settings.CacheTtlMinutes));
-                }
-                if (encrypted.Length < 1 + 12 + 16) return NotFound();
-                if (encrypted[0] != 1) return NotFound();
-                var nonce = encrypted.AsSpan(1, 12).ToArray();
-                var tag = encrypted.AsSpan(encrypted.Length - 16, 16).ToArray();
-                var cipher = encrypted.AsSpan(13, encrypted.Length - 13 - 16).ToArray();
-
+                if (!view.Encrypted) return NotFound();
                 var events = await _query.Events.FetchStreamAsync(documentId, token: ct);
-                var keysEvent = events.Select(e => e.Data).OfType<DocumentEncryptionKeysAdded>().LastOrDefault();
-                if (keysEvent == null) return NotFound();
-                var entry = keysEvent.Artifacts.FirstOrDefault(a => a.Artifact == artifactWire);
-                if (entry == null) return NotFound();
-                if (entry.WrappedDek.Length < 32 + 16) return NotFound();
-                var wrapped = entry.WrappedDek.AsSpan(0, 32).ToArray();
-                var wrapTag = entry.WrappedDek.AsSpan(32, 16).ToArray();
-
-                var dek = new byte[32];
-                try
-                {
-                    using var aesWrap = new System.Security.Cryptography.AesGcm(Convert.FromBase64String(_settings.MasterKeyBase64), 16);
-                    aesWrap.Decrypt(entry.WrapNonce, wrapped, wrapTag, dek, System.Text.Encoding.UTF8.GetBytes("DEK:" + artifactWire));
-                }
-                catch { return NotFound(); }
-
-                var plain = new byte[cipher.Length];
-                try
-                {
-                    using var aes = new System.Security.Cryptography.AesGcm(dek, 16);
-                    aes.Decrypt(nonce, cipher, tag, plain);
-                }
-                catch { return NotFound(); }
-
-                ApplyClientCacheHeaders();
-                return File(plain, GetContentType(artifact, fullPath));
+                encryptionKeys = events.Select(e => e.Data).OfType<DocumentEncryptionKeysAdded>().LastOrDefault();
+                if (encryptionKeys == null) return NotFound();
             }
-            else
-            {
-                var plainBytes = await _storage.GetFileAsync(fullPath, ct);
-                ApplyClientCacheHeaders();
-                return File(plainBytes, GetContentType(artifact, fullPath));
-            }
+
+            var contentBytes = await TryGetArtifactBytesAsync(view, artifact, fullPath, encryptionKeys, ct);
+            if (contentBytes == null) return NotFound();
+
+            var contentType = await GetContentTypeAsync(view, artifact, encryptionKeys, ct);
+
+            ApplyClientCacheHeaders();
+            return File(contentBytes, contentType);
         }
 
         private void ApplyClientCacheHeaders()
@@ -128,7 +96,99 @@ namespace ArquivoMate2.API.Controllers
             Response.Headers["Expires"] = DateTime.UtcNow.AddSeconds(OneYearSeconds).ToString("R");
         }
 
-        private static string GetContentType(DocumentArtifact artifact, string path) => artifact switch
+        private async Task<byte[]?> TryGetArtifactBytesAsync(DocumentView view, DocumentArtifact artifact, string fullPath, DocumentEncryptionKeysAdded? encryptionKeys, CancellationToken ct)
+        {
+            if (_settings.Enabled)
+            {
+                if (encryptionKeys == null) return null;
+
+                byte[]? encrypted = null;
+                var artifactWire = artifact.ToWireValue();
+                var cacheKey = $"encfile:{view.Id}:{artifactWire}";
+
+                var cached = await _cache.GetAsync<byte[]>(cacheKey);
+                if (cached.HasValue) encrypted = cached.Value;
+                if (encrypted == null)
+                {
+                    encrypted = await _storage.GetFileAsync(fullPath, ct);
+                    await _cache.SetAsync(cacheKey, encrypted, TimeSpan.FromMinutes(_settings.CacheTtlMinutes));
+                }
+
+                if (encrypted.Length < 1 + 12 + 16) return null;
+                if (encrypted[0] != 1) return null;
+
+                var nonce = encrypted.AsSpan(1, 12).ToArray();
+                var tag = encrypted.AsSpan(encrypted.Length - 16, 16).ToArray();
+                var cipher = encrypted.AsSpan(13, encrypted.Length - 13 - 16).ToArray();
+
+                var entry = encryptionKeys.Artifacts.FirstOrDefault(a => a.Artifact == artifactWire);
+                if (entry == null || entry.WrappedDek.Length < 32 + 16) return null;
+
+                var wrapped = entry.WrappedDek.AsSpan(0, 32).ToArray();
+                var wrapTag = entry.WrappedDek.AsSpan(32, 16).ToArray();
+
+                var dek = new byte[32];
+                try
+                {
+                    using var aesWrap = new AesGcm(Convert.FromBase64String(_settings.MasterKeyBase64), 16);
+                    aesWrap.Decrypt(entry.WrapNonce, wrapped, wrapTag, dek, Encoding.UTF8.GetBytes("DEK:" + artifactWire));
+                }
+                catch
+                {
+                    return null;
+                }
+
+                var plain = new byte[cipher.Length];
+                try
+                {
+                    using var aes = new AesGcm(dek, 16);
+                    aes.Decrypt(nonce, cipher, tag, plain);
+                }
+                catch
+                {
+                    return null;
+                }
+
+                return plain;
+            }
+
+            return await _storage.GetFileAsync(fullPath, ct);
+        }
+
+        private async Task<string> GetContentTypeAsync(DocumentView view, DocumentArtifact artifact, DocumentEncryptionKeysAdded? encryptionKeys, CancellationToken ct)
+        {
+            if (artifact == DocumentArtifact.File)
+            {
+                var mime = await TryGetMimeTypeFromMetadataAsync(view, encryptionKeys, ct);
+                if (!string.IsNullOrWhiteSpace(mime)) return mime;
+            }
+
+            return GetDefaultContentType(artifact);
+        }
+
+        private async Task<string?> TryGetMimeTypeFromMetadataAsync(DocumentView view, DocumentEncryptionKeysAdded? encryptionKeys, CancellationToken ct)
+        {
+            if (string.IsNullOrEmpty(view.MetadataPath)) return null;
+
+            try
+            {
+                var metadataBytes = await TryGetArtifactBytesAsync(view, DocumentArtifact.Metadata, view.MetadataPath, encryptionKeys, ct);
+                if (metadataBytes == null) return null;
+
+                var metadata = JsonSerializer.Deserialize<DocumentMetadata>(metadataBytes, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return string.IsNullOrWhiteSpace(metadata?.MimeType) ? null : metadata.MimeType;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetDefaultContentType(DocumentArtifact artifact) => artifact switch
         {
             DocumentArtifact.Thumb => "image/webp",
             DocumentArtifact.Metadata => "application/json",


### PR DESCRIPTION
## Summary
- centralize artifact retrieval in the delivery controller so encrypted and plain payloads share one code path
- derive the delivered file MIME type from the stored metadata when available to avoid forcing PDF types

## Testing
- dotnet build *(fails: MSB1011, specify solution because multiple project files are present)*

------
https://chatgpt.com/codex/tasks/task_e_68e40e914e548324b40938613cbc43b3