### PR TITLE
Implement streaming storage and encryption

### DIFF
--- a/src/ArquivoMate2.Application/Interfaces/IDocumentProcessor.cs
+++ b/src/ArquivoMate2.Application/Interfaces/IDocumentProcessor.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ArquivoMate2.Application.Interfaces
@@ -9,11 +7,11 @@ namespace ArquivoMate2.Application.Interfaces
     public interface IDocumentProcessor
     {
         Task<string> ExtractPdfTextAsync(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, bool forceOcr, CancellationToken cancellationToken = default);
-        
-        Task<string> ExtractImageTextAsync(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, CancellationToken cancellationToken = default);
-        
-        Task<byte[]> GeneratePreviewPdf(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, CancellationToken cancellationToken = default);
 
-        Task<byte[]> GenerateArchivePdf(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, CancellationToken cancellationToken = default);
+        Task<string> ExtractImageTextAsync(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, CancellationToken cancellationToken = default);
+
+        Task GeneratePreviewPdf(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, Stream output, CancellationToken cancellationToken = default);
+
+        Task GenerateArchivePdf(Stream documentStream, Domain.ValueObjects.DocumentMetadata documentMetadata, Stream output, CancellationToken cancellationToken = default);
     }
 }

--- a/src/ArquivoMate2.Application/Interfaces/IEncryptionService.cs
+++ b/src/ArquivoMate2.Application/Interfaces/IEncryptionService.cs
@@ -1,10 +1,14 @@
 using ArquivoMate2.Domain.Document;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ArquivoMate2.Application.Interfaces
 {
     public interface IEncryptionService
     {
         Task<(string fullPath, EncryptedArtifactKey? key)> SaveAsync(string userId, Guid documentId, string filename, byte[] content, string artifact, CancellationToken ct = default);
+        Task<(string fullPath, EncryptedArtifactKey? key)> SaveAsync(string userId, Guid documentId, string filename, Stream content, string artifact, CancellationToken ct = default);
         bool IsEnabled { get; }
     }
 }

--- a/src/ArquivoMate2.Application/Interfaces/IStorageProvider.cs
+++ b/src/ArquivoMate2.Application/Interfaces/IStorageProvider.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ArquivoMate2.Application.Interfaces
@@ -6,6 +8,7 @@ namespace ArquivoMate2.Application.Interfaces
     public interface IStorageProvider
     {
         Task<string> SaveFile(string userId, Guid documentId, string filename, byte[] file, string artifact = "file");
+        Task<string> SaveFileAsync(string userId, Guid documentId, string filename, Stream content, string artifact = "file", CancellationToken ct = default);
         Task<byte[]> GetFileAsync(string fullPath, CancellationToken ct = default); // NEW
     }
 }

--- a/src/ArquivoMate2.Infrastructure/Services/Encryption/EncryptionService.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/Encryption/EncryptionService.cs
@@ -1,9 +1,14 @@
-using System.Security.Cryptography;
-using System.Text;
 using ArquivoMate2.Application.Configuration;
 using ArquivoMate2.Application.Interfaces;
 using ArquivoMate2.Domain.Document;
 using Microsoft.Extensions.Options;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ArquivoMate2.Infrastructure.Services.Encryption
 {
@@ -32,49 +37,106 @@ namespace ArquivoMate2.Infrastructure.Services.Encryption
 
         public async Task<(string fullPath, EncryptedArtifactKey? key)> SaveAsync(string userId, Guid documentId, string filename, byte[] content, string artifact, CancellationToken ct = default)
         {
+            using var ms = new MemoryStream(content, writable: false);
+            return await SaveAsync(userId, documentId, filename, ms, artifact, ct).ConfigureAwait(false);
+        }
+
+        public async Task<(string fullPath, EncryptedArtifactKey? key)> SaveAsync(string userId, Guid documentId, string filename, Stream content, string artifact, CancellationToken ct = default)
+        {
+            if (content.CanSeek)
+            {
+                content.Position = 0;
+            }
+
             if (!IsEnabled)
             {
-                var pPlain = await _inner.SaveFile(userId, documentId, filename, content, artifact);
+                var pPlain = await _inner.SaveFileAsync(userId, documentId, filename, content, artifact, ct).ConfigureAwait(false);
                 return (pPlain, null);
             }
 
-            // Generate DEK (persist as byte[] because we cross an await)
             var dek = RandomNumberGenerator.GetBytes(32); // 256 bit
+            var (encKey, macKey) = DeriveSubKeys(dek);
+            var iv = RandomNumberGenerator.GetBytes(16);
 
-            // Encrypt payload with DEK (AES-GCM)
-            var nonce = RandomNumberGenerator.GetBytes(12);
-            var tag = new byte[16];
-            var cipher = new byte[content.Length];
-            using (var aes = new AesGcm(dek, 16))
+            await using var cipherStream = CreateTempFileStream();
+            using (var aes = Aes.Create())
             {
-                aes.Encrypt(nonce, content, cipher, tag);
+                aes.Key = encKey;
+                aes.IV = iv;
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+
+                using var encryptor = aes.CreateEncryptor();
+                using var cryptoStream = new CryptoStream(cipherStream, encryptor, CryptoStreamMode.Write, leaveOpen: true);
+                await content.CopyToAsync(cryptoStream, 81920, ct).ConfigureAwait(false);
+                cryptoStream.FlushFinalBlock();
             }
 
-            // Layout: [1][nonce][cipher][tag]
-            byte version = 1;
-            var encryptedBytes = new byte[1 + nonce.Length + cipher.Length + tag.Length];
-            encryptedBytes[0] = version;
-            Buffer.BlockCopy(nonce, 0, encryptedBytes, 1, nonce.Length);
-            Buffer.BlockCopy(cipher, 0, encryptedBytes, 1 + nonce.Length, cipher.Length);
-            Buffer.BlockCopy(tag, 0, encryptedBytes, 1 + nonce.Length + cipher.Length, tag.Length);
+            cipherStream.Position = 0;
 
-            var encryptedFilename = filename + ".enc";
-            var fullPath = await _inner.SaveFile(userId, documentId, encryptedFilename, encryptedBytes, artifact);
-
-            // Wrap DEK with KEK (AES-GCM); AD = "DEK:" + artifact
-            var wrapNonce = RandomNumberGenerator.GetBytes(12);
-            var wrapped = new byte[dek.Length];
-            var wrapTag = new byte[16];
-            using (var aesWrap = new AesGcm(_kek, 16))
+            var buffer = ArrayPool<byte>.Shared.Rent(81920);
+            try
             {
-                aesWrap.Encrypt(wrapNonce, dek, wrapped, wrapTag, Encoding.UTF8.GetBytes("DEK:" + artifact));
-            }
-            var wrappedConcat = new byte[wrapped.Length + wrapTag.Length];
-            Buffer.BlockCopy(wrapped, 0, wrappedConcat, 0, wrapped.Length);
-            Buffer.BlockCopy(wrapTag, 0, wrappedConcat, wrapped.Length, wrapTag.Length);
+                using var hmac = new HMACSHA256(macKey);
+                hmac.TransformBlock(iv, 0, iv.Length, null, 0);
 
-            var keyRecord = new EncryptedArtifactKey(artifact, wrappedConcat, wrapNonce, "AES-256-GCM", "1");
-            return (fullPath, keyRecord);
+                int read;
+                while ((read = await cipherStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false)) > 0)
+                {
+                    hmac.TransformBlock(buffer, 0, read, null, 0);
+                }
+                hmac.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                var mac = hmac.Hash ?? throw new InvalidOperationException("Failed to compute HMAC for encrypted content.");
+
+                cipherStream.Position = 0;
+
+                await using var envelopeStream = CreateTempFileStream();
+                await envelopeStream.WriteAsync(new[] { (byte)2 }, ct).ConfigureAwait(false);
+                await envelopeStream.WriteAsync(iv, ct).ConfigureAwait(false);
+
+                while ((read = await cipherStream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false)) > 0)
+                {
+                    await envelopeStream.WriteAsync(buffer.AsMemory(0, read), ct).ConfigureAwait(false);
+                }
+
+                await envelopeStream.WriteAsync(mac, ct).ConfigureAwait(false);
+                envelopeStream.Position = 0;
+
+                var encryptedFilename = filename + ".enc";
+                var fullPath = await _inner.SaveFileAsync(userId, documentId, encryptedFilename, envelopeStream, artifact, ct).ConfigureAwait(false);
+
+                var wrapNonce = RandomNumberGenerator.GetBytes(12);
+                var wrapped = new byte[dek.Length];
+                var wrapTag = new byte[16];
+                using (var aesWrap = new AesGcm(_kek, 16))
+                {
+                    aesWrap.Encrypt(wrapNonce, dek, wrapped, wrapTag, Encoding.UTF8.GetBytes("DEK:" + artifact));
+                }
+                var wrappedConcat = new byte[wrapped.Length + wrapTag.Length];
+                Buffer.BlockCopy(wrapped, 0, wrappedConcat, 0, wrapped.Length);
+                Buffer.BlockCopy(wrapTag, 0, wrappedConcat, wrapped.Length, wrapTag.Length);
+
+                var keyRecord = new EncryptedArtifactKey(artifact, wrappedConcat, wrapNonce, "AES-256-CBC-HMACSHA256", "2");
+                return (fullPath, keyRecord);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        private static (byte[] EncKey, byte[] MacKey) DeriveSubKeys(byte[] dek)
+        {
+            using var hmac = new HMACSHA256(dek);
+            var encKey = hmac.ComputeHash(Encoding.UTF8.GetBytes("enc"));
+            var macKey = hmac.ComputeHash(Encoding.UTF8.GetBytes("mac"));
+            return (encKey, macKey);
+        }
+
+        private static FileStream CreateTempFileStream()
+        {
+            var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            return new FileStream(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
         }
     }
 }

--- a/src/ArquivoMate2.Infrastructure/Services/StorageProvider/StorageProviderBase.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/StorageProvider/StorageProviderBase.cs
@@ -1,6 +1,9 @@
 using ArquivoMate2.Application.Interfaces;
 using ArquivoMate2.Infrastructure.Configuration.StorageProvider;
 using Microsoft.Extensions.Options;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ArquivoMate2.Infrastructure.Services.StorageProvider
 {
@@ -27,7 +30,13 @@ namespace ArquivoMate2.Infrastructure.Services.StorageProvider
             return root + "/" + string.Join('/', parts);
         }
 
-        public abstract Task<string> SaveFile(string userId, Guid documentId, string filename, byte[] file, string artifact = "file");
+        public virtual async Task<string> SaveFile(string userId, Guid documentId, string filename, byte[] file, string artifact = "file")
+        {
+            using var stream = new MemoryStream(file, writable: false);
+            return await SaveFileAsync(userId, documentId, filename, stream, artifact).ConfigureAwait(false);
+        }
+
+        public abstract Task<string> SaveFileAsync(string userId, Guid documentId, string filename, Stream content, string artifact = "file", CancellationToken ct = default);
         public abstract Task<byte[]> GetFileAsync(string fullPath, CancellationToken ct = default);
     }
 }


### PR DESCRIPTION
## Summary
- add streaming save support to storage interfaces and S3 provider
- update document processing to generate preview/archive PDFs into target streams and persist derivatives without buffering
- implement streaming-aware encryption and extend artifact consumers to handle the new encrypted format

## Testing
- `dotnet build ArquivoMate2.sln` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c045e9508324956632128a615504