### PR TITLE
Implement streaming artifact downloads

### DIFF
--- a/src/ArquivoMate2.API/Controllers/PublicShareController.cs
+++ b/src/ArquivoMate2.API/Controllers/PublicShareController.cs
@@ -1,3 +1,4 @@
+using ArquivoMate2.API.Results;
 using ArquivoMate2.Application.Configuration;
 using ArquivoMate2.Application.Interfaces;
 using ArquivoMate2.Domain.Sharing;
@@ -42,8 +43,8 @@ namespace ArquivoMate2.API.Controllers
 
             try
             {
-                var (content, contentType) = await _streamer.GetAsync(share.DocumentId, share.Artifact, ct);
-                return File(content, contentType);
+                var (writeAsync, contentType) = await _streamer.GetAsync(share.DocumentId, share.Artifact, ct);
+                return new PushStreamResult(contentType, writeAsync);
             }
             catch
             {

--- a/src/ArquivoMate2.API/Results/PushStreamResult.cs
+++ b/src/ArquivoMate2.API/Results/PushStreamResult.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ArquivoMate2.API.Results
+{
+    public class PushStreamResult : FileResult
+    {
+        private readonly Func<Stream, CancellationToken, Task> _writeToResponse;
+
+        public PushStreamResult(string contentType, Func<Stream, CancellationToken, Task> writeToResponse)
+            : base(contentType)
+        {
+            _writeToResponse = writeToResponse ?? throw new ArgumentNullException(nameof(writeToResponse));
+        }
+
+        protected override Task WriteFileAsync(HttpContext context, Stream responseStream)
+        {
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            return _writeToResponse(responseStream, context.RequestAborted);
+        }
+    }
+}

--- a/src/ArquivoMate2.Application/Interfaces/IDocumentArtifactStreamer.cs
+++ b/src/ArquivoMate2.Application/Interfaces/IDocumentArtifactStreamer.cs
@@ -1,7 +1,12 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace ArquivoMate2.Application.Interfaces
 {
     public interface IDocumentArtifactStreamer
     {
-        Task<(byte[] Content, string ContentType)> GetAsync(Guid documentId, string artifact, CancellationToken ct);
+        Task<(Func<Stream, CancellationToken, Task> WriteToAsync, string ContentType)> GetAsync(Guid documentId, string artifact, CancellationToken ct);
     }
 }

--- a/src/ArquivoMate2.Application/Interfaces/IStorageProvider.cs
+++ b/src/ArquivoMate2.Application/Interfaces/IStorageProvider.cs
@@ -10,5 +10,6 @@ namespace ArquivoMate2.Application.Interfaces
         Task<string> SaveFile(string userId, Guid documentId, string filename, byte[] file, string artifact = "file");
         Task<string> SaveFileAsync(string userId, Guid documentId, string filename, Stream content, string artifact = "file", CancellationToken ct = default);
         Task<byte[]> GetFileAsync(string fullPath, CancellationToken ct = default); // NEW
+        Task StreamFileAsync(string fullPath, Func<Stream, CancellationToken, Task> streamConsumer, CancellationToken ct = default);
     }
 }

--- a/src/ArquivoMate2.Infrastructure/Services/DocumentArtifactStreamer.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/DocumentArtifactStreamer.cs
@@ -3,9 +3,15 @@ using ArquivoMate2.Application.Interfaces;
 using ArquivoMate2.Domain.Document;
 using ArquivoMate2.Infrastructure.Persistance;
 using Marten;
+using Marten.Events;
+using System;
+using System.Buffers;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ArquivoMate2.Infrastructure.Services
 {
@@ -22,13 +28,14 @@ namespace ArquivoMate2.Infrastructure.Services
             _enc = enc;
         }
 
-        private static readonly string[] Artifacts = ["file","preview","thumb","metadata","archive"];
+        private static readonly string[] Artifacts = ["file", "preview", "thumb", "metadata", "archive"];
 
-        public async Task<(byte[] Content, string ContentType)> GetAsync(Guid documentId, string artifact, CancellationToken ct)
+        public async Task<(Func<Stream, CancellationToken, Task> WriteToAsync, string ContentType)> GetAsync(Guid documentId, string artifact, CancellationToken ct)
         {
             if (!Artifacts.Contains(artifact)) throw new FileNotFoundException();
-            var view = await _query.Query<DocumentView>().Where(d => d.Id == documentId && !d.Deleted).FirstOrDefaultAsync(ct);
-            if (view == null) throw new FileNotFoundException();
+
+            var view = await _query.LoadAsync<DocumentView>(documentId, ct).ConfigureAwait(false);
+            if (view == null || view.Deleted) throw new FileNotFoundException();
 
             string? path = artifact switch
             {
@@ -43,72 +50,170 @@ namespace ArquivoMate2.Infrastructure.Services
 
             if (_enc.Enabled && view.Encrypted)
             {
-                var bytes = await _storage.GetFileAsync(path, ct);
-                if (bytes.Length < 1) throw new FileNotFoundException();
-
-                var events = await _query.Events.FetchStreamAsync(documentId, token: ct);
+                var events = await _query.Events.FetchStreamAsync(documentId, token: ct).ConfigureAwait(false);
                 var keysEvent = events.Select(e => e.Data).OfType<DocumentEncryptionKeysAdded>().LastOrDefault();
                 if (keysEvent == null) throw new FileNotFoundException();
+
                 var entry = keysEvent.Artifacts.FirstOrDefault(a => a.Artifact == artifact);
                 if (entry == null || entry.WrappedDek.Length < 48) throw new FileNotFoundException();
+
                 var wrapped = entry.WrappedDek.AsSpan(0, 32).ToArray();
                 var wrapTag = entry.WrappedDek.AsSpan(32, 16).ToArray();
                 var dek = new byte[32];
+
                 using (var aesWrap = new AesGcm(Convert.FromBase64String(_enc.MasterKeyBase64), 16))
                 {
                     aesWrap.Decrypt(entry.WrapNonce, wrapped, wrapTag, dek, Encoding.UTF8.GetBytes("DEK:" + artifact));
                 }
 
-                byte version = bytes[0];
-                if (version == 1)
+                return (async (destination, writeCt) =>
                 {
-                    if (bytes.Length < 1 + 12 + 16) throw new FileNotFoundException();
-                    var nonce = bytes.AsSpan(1, 12).ToArray();
-                    var tag = bytes.AsSpan(bytes.Length - 16, 16).ToArray();
-                    var cipher = bytes.AsSpan(13, bytes.Length - 13 - 16).ToArray();
-
-                    var plain = new byte[cipher.Length];
-                    using (var aes = new AesGcm(dek, 16))
-                    {
-                        aes.Decrypt(nonce, cipher, tag, plain);
-                    }
-                    return (plain, MapContentType(artifact, path));
-                }
-
-                if (version == 2)
-                {
-                    if (bytes.Length < 1 + 16 + 32) throw new FileNotFoundException();
-                    var iv = bytes.AsSpan(1, 16).ToArray();
-                    var mac = bytes.AsSpan(bytes.Length - 32, 32).ToArray();
-                    var cipherLength = bytes.Length - 1 - iv.Length - mac.Length;
-                    if (cipherLength < 0) throw new FileNotFoundException();
-                    var cipher = bytes.AsSpan(1 + iv.Length, cipherLength).ToArray();
-
-                    var (encKey, macKey) = DeriveSubKeys(dek);
-                    using (var hmac = new HMACSHA256(macKey))
-                    {
-                        hmac.TransformBlock(iv, 0, iv.Length, null, 0);
-                        hmac.TransformBlock(cipher, 0, cipher.Length, null, 0);
-                        hmac.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
-                        var computed = hmac.Hash ?? Array.Empty<byte>();
-                        if (!CryptographicOperations.FixedTimeEquals(computed, mac)) throw new FileNotFoundException();
-                    }
-
-                    using var aes = Aes.Create();
-                    aes.Key = encKey;
-                    aes.IV = iv;
-                    aes.Mode = CipherMode.CBC;
-                    aes.Padding = PaddingMode.PKCS7;
-                    using var decryptor = aes.CreateDecryptor();
-                    var plain = decryptor.TransformFinalBlock(cipher, 0, cipher.Length);
-                    return (plain, MapContentType(artifact, path));
-                }
-
-                throw new FileNotFoundException();
+                    using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, writeCt);
+                    await _storage.StreamFileAsync(path, (encryptedStream, token) => StreamEncryptedArtifactAsync(encryptedStream, destination, dek, token), linked.Token).ConfigureAwait(false);
+                }, MapContentType(artifact, path));
             }
 
-            var plainBytes = await _storage.GetFileAsync(path, ct);
-            return (plainBytes, MapContentType(artifact, path));
+            return (async (destination, writeCt) =>
+            {
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, writeCt);
+                await _storage.StreamFileAsync(path, (source, token) => source.CopyToAsync(destination, 81920, token), linked.Token).ConfigureAwait(false);
+            }, MapContentType(artifact, path));
+        }
+
+        private static async Task StreamEncryptedArtifactAsync(Stream encryptedStream, Stream destination, byte[] dek, CancellationToken ct)
+        {
+            var version = await ReadByteAsync(encryptedStream, ct).ConfigureAwait(false);
+            if (version == -1) throw new FileNotFoundException();
+
+            try
+            {
+                switch (version)
+                {
+                    case 1:
+                        await StreamEncryptedVersion1Async(encryptedStream, destination, dek, ct).ConfigureAwait(false);
+                        break;
+                    case 2:
+                        await StreamEncryptedVersion2Async(encryptedStream, destination, dek, ct).ConfigureAwait(false);
+                        break;
+                    default:
+                        throw new FileNotFoundException();
+                }
+            }
+            catch (CryptographicException ex)
+            {
+                throw new FileNotFoundException("Unable to decrypt artifact.", ex);
+            }
+        }
+
+        private static async Task StreamEncryptedVersion1Async(Stream encryptedStream, Stream destination, byte[] dek, CancellationToken ct)
+        {
+            var nonce = await ReadExactlyAsync(encryptedStream, 12, ct).ConfigureAwait(false);
+
+            await using var bufferStream = new MemoryStream();
+            await encryptedStream.CopyToAsync(bufferStream, 81920, ct).ConfigureAwait(false);
+            if (bufferStream.Length < 16) throw new FileNotFoundException();
+
+            if (!bufferStream.TryGetBuffer(out var segment))
+            {
+                segment = new ArraySegment<byte>(bufferStream.ToArray());
+            }
+
+            var array = segment.Array ?? throw new FileNotFoundException();
+            var cipherLength = segment.Count - 16;
+            if (cipherLength < 0) throw new FileNotFoundException();
+
+            var cipher = new byte[cipherLength];
+            Buffer.BlockCopy(array, segment.Offset, cipher, 0, cipherLength);
+            var tag = new byte[16];
+            Buffer.BlockCopy(array, segment.Offset + cipherLength, tag, 0, 16);
+
+            using var aes = new AesGcm(dek, 16);
+            aes.Decrypt(nonce, cipher, tag, cipher);
+            await destination.WriteAsync(cipher.AsMemory(0, cipher.Length), ct).ConfigureAwait(false);
+        }
+
+        private static async Task StreamEncryptedVersion2Async(Stream encryptedStream, Stream destination, byte[] dek, CancellationToken ct)
+        {
+            var iv = await ReadExactlyAsync(encryptedStream, 16, ct).ConfigureAwait(false);
+            var (encKey, macKey) = DeriveSubKeys(dek);
+
+            using var hmac = new HMACSHA256(macKey);
+            hmac.TransformBlock(iv, 0, iv.Length, null, 0);
+
+            using var aes = Aes.Create();
+            aes.Key = encKey;
+            aes.IV = iv;
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.PKCS7;
+
+            await using var cryptoStream = new CryptoStream(destination, aes.CreateDecryptor(), CryptoStreamMode.Write, leaveOpen: true);
+
+            var buffer = ArrayPool<byte>.Shared.Rent(81920 + 32);
+            var buffered = 0;
+            int read;
+
+            try
+            {
+                while ((read = await encryptedStream.ReadAsync(buffer.AsMemory(buffered, buffer.Length - buffered), ct).ConfigureAwait(false)) > 0)
+                {
+                    buffered += read;
+                    if (buffered <= 32)
+                    {
+                        continue;
+                    }
+
+                    var cipherCount = buffered - 32;
+                    hmac.TransformBlock(buffer, 0, cipherCount, null, 0);
+                    await cryptoStream.WriteAsync(buffer.AsMemory(0, cipherCount), ct).ConfigureAwait(false);
+
+                    Buffer.BlockCopy(buffer, cipherCount, buffer, 0, 32);
+                    buffered = 32;
+                }
+
+                if (buffered != 32)
+                {
+                    throw new FileNotFoundException();
+                }
+
+                var mac = new byte[32];
+                Buffer.BlockCopy(buffer, 0, mac, 0, 32);
+
+                hmac.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                var computed = hmac.Hash ?? Array.Empty<byte>();
+                if (!CryptographicOperations.FixedTimeEquals(computed, mac))
+                {
+                    throw new FileNotFoundException();
+                }
+
+                cryptoStream.FlushFinalBlock();
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        private static async Task<int> ReadByteAsync(Stream stream, CancellationToken ct)
+        {
+            var buffer = new byte[1];
+            var read = await stream.ReadAsync(buffer.AsMemory(0, 1), ct).ConfigureAwait(false);
+            return read == 1 ? buffer[0] : -1;
+        }
+
+        private static async Task<byte[]> ReadExactlyAsync(Stream stream, int count, CancellationToken ct)
+        {
+            var buffer = new byte[count];
+            var offset = 0;
+            while (offset < count)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(offset, count - offset), ct).ConfigureAwait(false);
+                if (read == 0)
+                {
+                    throw new FileNotFoundException();
+                }
+                offset += read;
+            }
+            return buffer;
         }
 
         private static string MapContentType(string artifact, string path) => artifact switch

--- a/src/ArquivoMate2.Infrastructure/Services/DocumentArtifactStreamer.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/DocumentArtifactStreamer.cs
@@ -128,8 +128,9 @@ namespace ArquivoMate2.Infrastructure.Services
             Buffer.BlockCopy(array, segment.Offset + cipherLength, tag, 0, 16);
 
             using var aes = new AesGcm(dek, 16);
-            aes.Decrypt(nonce, cipher, tag, cipher);
-            await destination.WriteAsync(cipher.AsMemory(0, cipher.Length), ct).ConfigureAwait(false);
+            var plaintext = new byte[cipher.Length];
+            aes.Decrypt(nonce, cipher, tag, plaintext);
+            await destination.WriteAsync(plaintext.AsMemory(0, plaintext.Length), ct).ConfigureAwait(false);
         }
 
         private static async Task StreamEncryptedVersion2Async(Stream encryptedStream, Stream destination, byte[] dek, CancellationToken ct)

--- a/src/ArquivoMate2.Infrastructure/Services/StorageProvider/S3StorageProvider.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/StorageProvider/S3StorageProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using MimeTypes;
 using Minio;
 using Minio.DataModel.Args;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -64,6 +65,37 @@ namespace ArquivoMate2.Infrastructure.Services.StorageProvider
                 .WithCallbackStream(stream => stream.CopyTo(ms));
             await _storage.GetObjectAsync(args, ct).ConfigureAwait(false);
             return ms.ToArray();
+        }
+
+        public override async Task StreamFileAsync(string fullPath, Func<Stream, CancellationToken, Task> streamConsumer, CancellationToken ct = default)
+        {
+            if (streamConsumer == null) throw new ArgumentNullException(nameof(streamConsumer));
+
+            Exception? callbackException = null;
+            var args = new GetObjectArgs()
+                .WithBucket(_settings.BucketName)
+                .WithObject(fullPath)
+                .WithCallbackStream(stream =>
+                {
+                    try
+                    {
+                        streamConsumer(stream, ct).GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        callbackException = ex;
+                        throw;
+                    }
+                });
+
+            try
+            {
+                await _storage.GetObjectAsync(args, ct).ConfigureAwait(false);
+            }
+            catch when (callbackException != null)
+            {
+                throw callbackException;
+            }
         }
     }
 }

--- a/src/ArquivoMate2.Infrastructure/Services/StorageProvider/StorageProviderBase.cs
+++ b/src/ArquivoMate2.Infrastructure/Services/StorageProvider/StorageProviderBase.cs
@@ -1,6 +1,7 @@
 using ArquivoMate2.Application.Interfaces;
 using ArquivoMate2.Infrastructure.Configuration.StorageProvider;
 using Microsoft.Extensions.Options;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,5 +39,6 @@ namespace ArquivoMate2.Infrastructure.Services.StorageProvider
 
         public abstract Task<string> SaveFileAsync(string userId, Guid documentId, string filename, Stream content, string artifact = "file", CancellationToken ct = default);
         public abstract Task<byte[]> GetFileAsync(string fullPath, CancellationToken ct = default);
+        public abstract Task StreamFileAsync(string fullPath, Func<Stream, CancellationToken, Task> streamConsumer, CancellationToken ct = default);
     }
 }

--- a/tests/ArquivoMate2.Infrastructure.Tests/DocumentArtifactStreamerTests.cs
+++ b/tests/ArquivoMate2.Infrastructure.Tests/DocumentArtifactStreamerTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using ArquivoMate2.Application.Configuration;
+using ArquivoMate2.Application.Interfaces;
+using ArquivoMate2.Domain.Document;
+using ArquivoMate2.Infrastructure.Persistance;
+using ArquivoMate2.Infrastructure.Services;
+using Marten;
+using Marten.Events;
+using Moq;
+using Xunit;
+
+namespace ArquivoMate2.Infrastructure.Tests
+{
+    public class DocumentArtifactStreamerTests
+    {
+        [Fact]
+        public async Task GetAsync_ReturnsPlainArtifactStream()
+        {
+            var documentId = Guid.NewGuid();
+            var artifact = "file";
+            var view = new DocumentView
+            {
+                Id = documentId,
+                FilePath = "doc/file.pdf",
+                Encrypted = false,
+                Deleted = false
+            };
+
+            var query = new Mock<IQuerySession>();
+            query.Setup(q => q.LoadAsync<DocumentView>(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(view);
+
+            var storage = new Mock<IStorageProvider>();
+            var plainBytes = Encoding.UTF8.GetBytes("plain document content");
+            storage.Setup(s => s.StreamFileAsync(view.FilePath, It.IsAny<Func<Stream, CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+                .Returns<string, Func<Stream, CancellationToken, Task>, CancellationToken>((_, callback, token) =>
+                    Task.Run(async () =>
+                    {
+                        await using var source = new MemoryStream(plainBytes, writable: false);
+                        await callback(source, token).ConfigureAwait(false);
+                    }));
+
+            var streamer = new DocumentArtifactStreamer(query.Object, storage.Object, new EncryptionSettings { Enabled = false });
+
+            var (writeAsync, contentType) = await streamer.GetAsync(documentId, artifact, CancellationToken.None);
+
+            await using var destination = new MemoryStream();
+            await writeAsync(destination, CancellationToken.None);
+
+            Assert.Equal("application/pdf", contentType);
+            Assert.Equal(plainBytes, destination.ToArray());
+
+            storage.Verify(s => s.StreamFileAsync(view.FilePath, It.IsAny<Func<Stream, CancellationToken, Task>>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetAsync_DecryptsVersion2ArtifactStream()
+        {
+            var documentId = Guid.NewGuid();
+            var artifact = "file";
+            var masterKey = Enumerable.Range(1, 32).Select(i => (byte)i).ToArray();
+            var encryptionSettings = new EncryptionSettings
+            {
+                Enabled = true,
+                MasterKeyBase64 = Convert.ToBase64String(masterKey)
+            };
+
+            var view = new DocumentView
+            {
+                Id = documentId,
+                FilePath = "doc/file.enc",
+                Encrypted = true,
+                Deleted = false
+            };
+
+            var query = new Mock<IQuerySession>();
+            query.Setup(q => q.LoadAsync<DocumentView>(documentId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(view);
+
+            var eventStore = new Mock<IEventStore>();
+            query.SetupGet(q => q.Events).Returns(eventStore.Object);
+
+            var dek = Enumerable.Range(33, 32).Select(i => (byte)i).ToArray();
+            var wrapNonce = Enumerable.Range(65, 12).Select(i => (byte)i).ToArray();
+            var wrapped = new byte[dek.Length];
+            var wrapTag = new byte[16];
+            using (var aesWrap = new AesGcm(masterKey, 16))
+            {
+                aesWrap.Encrypt(wrapNonce, dek, wrapped, wrapTag, Encoding.UTF8.GetBytes("DEK:" + artifact));
+            }
+            var wrappedDek = new byte[wrapped.Length + wrapTag.Length];
+            Buffer.BlockCopy(wrapped, 0, wrappedDek, 0, wrapped.Length);
+            Buffer.BlockCopy(wrapTag, 0, wrappedDek, wrapped.Length, wrapTag.Length);
+
+            var keysEvent = new DocumentEncryptionKeysAdded(documentId,
+                new[] { new EncryptedArtifactKey(artifact, wrappedDek, wrapNonce, "AES-256-CBC-HMACSHA256", "2") },
+                DateTime.UtcNow);
+
+            var eventMock = new Mock<IEvent>();
+            eventMock.SetupGet(e => e.Data).Returns(keysEvent);
+
+            eventStore.Setup(e => e.FetchStreamAsync(documentId, 0, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<IEvent> { eventMock.Object });
+
+            var plainBytes = Encoding.UTF8.GetBytes("super secret document");
+            var (encKey, macKey) = DeriveSubKeys(dek);
+            var iv = Enumerable.Range(97, 16).Select(i => (byte)i).ToArray();
+            byte[] cipher;
+            using (var aes = Aes.Create())
+            {
+                aes.Key = encKey;
+                aes.IV = iv;
+                aes.Mode = CipherMode.CBC;
+                aes.Padding = PaddingMode.PKCS7;
+                using var encryptor = aes.CreateEncryptor();
+                cipher = encryptor.TransformFinalBlock(plainBytes, 0, plainBytes.Length);
+            }
+
+            byte[] mac;
+            using (var hmac = new HMACSHA256(macKey))
+            {
+                hmac.TransformBlock(iv, 0, iv.Length, null, 0);
+                hmac.TransformBlock(cipher, 0, cipher.Length, null, 0);
+                hmac.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                mac = hmac.Hash ?? Array.Empty<byte>();
+            }
+
+            var encrypted = new byte[1 + iv.Length + cipher.Length + mac.Length];
+            encrypted[0] = 2;
+            Buffer.BlockCopy(iv, 0, encrypted, 1, iv.Length);
+            Buffer.BlockCopy(cipher, 0, encrypted, 1 + iv.Length, cipher.Length);
+            Buffer.BlockCopy(mac, 0, encrypted, 1 + iv.Length + cipher.Length, mac.Length);
+
+            var storage = new Mock<IStorageProvider>();
+            storage.Setup(s => s.StreamFileAsync(view.FilePath, It.IsAny<Func<Stream, CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+                .Returns<string, Func<Stream, CancellationToken, Task>, CancellationToken>((_, callback, token) =>
+                    Task.Run(async () =>
+                    {
+                        await using var source = new MemoryStream(encrypted, writable: false);
+                        await callback(source, token).ConfigureAwait(false);
+                    }));
+
+            var streamer = new DocumentArtifactStreamer(query.Object, storage.Object, encryptionSettings);
+
+            var (writeAsync, contentType) = await streamer.GetAsync(documentId, artifact, CancellationToken.None);
+
+            await using var destination = new MemoryStream();
+            await writeAsync(destination, CancellationToken.None);
+
+            Assert.Equal("application/pdf", contentType);
+            Assert.Equal(plainBytes, destination.ToArray());
+        }
+
+        private static (byte[] EncKey, byte[] MacKey) DeriveSubKeys(byte[] dek)
+        {
+            using var hmac = new HMACSHA256(dek);
+            var encKey = hmac.ComputeHash(Encoding.UTF8.GetBytes("enc"));
+            var macKey = hmac.ComputeHash(Encoding.UTF8.GetBytes("mac"));
+            return (encKey, macKey);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a streaming read callback to `IStorageProvider` and implement it for the S3 provider
- update `DocumentArtifactStreamer` to emit streaming responses (including CryptoStream decryption) and expose a push-style result for controllers
- switch `PublicShareController` to stream document artifacts directly and cover encrypted/unencrypted downloads with new tests

## Testing
- `dotnet test ArquivoMate2.sln --no-restore` *(fails: unable to reach https://api.nuget.org/v3/index.json via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c04ff6c08324aa8e47d8d25fb357