### PR TITLE
Add next/previous navigation to document detail view

### DIFF
--- a/src/ArquivoMate2.Ui/public/i18n/de.json
+++ b/src/ArquivoMate2.Ui/public/i18n/de.json
@@ -15,6 +15,8 @@
     "NoteSaved": "Notiz gespeichert",
     "NotesLoadError": "Notizen konnten nicht geladen werden",
     "Back": "Zurück",
+    "Previous": "Vorheriges",
+    "Next": "Nächstes",
     "DocumentTitleFallback": "Dokument",
     "LoadingEllipsis": "Lädt…",
     "Open": "Öffnen",

--- a/src/ArquivoMate2.Ui/public/i18n/en.json
+++ b/src/ArquivoMate2.Ui/public/i18n/en.json
@@ -24,6 +24,8 @@
   "NoNotes": "No notes yet",
   "NoteSaved": "Note saved",
     "Back": "Back",
+    "Previous": "Previous",
+    "Next": "Next",
     "DocumentTitleFallback": "Document",
     "LoadingEllipsis": "Loading…",
     "Open": "Open",

--- a/src/ArquivoMate2.Ui/public/i18n/ru.json
+++ b/src/ArquivoMate2.Ui/public/i18n/ru.json
@@ -23,6 +23,8 @@
     "NoteSaved": "Заметка сохранена",
     "NotesLoadError": "Не удалось загрузить заметки",
     "Back": "Назад",
+    "Previous": "Предыдущий",
+    "Next": "Следующий",
     "DocumentTitleFallback": "Документ",
     "LoadingEllipsis": "Загрузка…",
     "Open": "Открыть",

--- a/src/ArquivoMate2.Ui/src/app/main/pages/dashboard/dashboard.component.ts
+++ b/src/ArquivoMate2.Ui/src/app/main/pages/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import { UploadWidgetComponent } from './upload-widget.component';
 import { DocumentCardGridComponent } from '../../../components/document-card-grid/document-card-grid.component';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { DocumentNavigationService } from '../../../services/document-navigation.service';
 
 
 @Component({
@@ -19,6 +20,7 @@ import { Router } from '@angular/router';
 export class DashboardComponent {
   private facade = inject(DocumentsFacadeService);
   private router = inject(Router);
+  private navigation = inject(DocumentNavigationService);
   documents = this.facade.documents;
   total = this.facade.totalCount;
   isLoading = this.facade.isLoading;
@@ -38,7 +40,27 @@ export class DashboardComponent {
   onReload() { this.facade.load(true); }
   onItemClick(doc: any) {
     if (doc?.id) {
-      this.router.navigate(['/app/document', doc.id]);
+      const list = this.documents();
+      const page = this.currentPage();
+      const pageSize = this.pageSize();
+      const search = (this.currentSearch() || '').trim();
+
+      this.navigation.prepare({
+        page,
+        pageSize,
+        search,
+        list: list || null,
+      });
+
+      const queryParams: Record<string, any> = {
+        page,
+        pageSize,
+      };
+      if (search) {
+        queryParams['search'] = search;
+      }
+
+      this.router.navigate(['/app/document', doc.id], { queryParams });
     }
   }
 

--- a/src/ArquivoMate2.Ui/src/app/main/pages/document/document.component.html
+++ b/src/ArquivoMate2.Ui/src/app/main/pages/document/document.component.html
@@ -3,10 +3,12 @@
 	<div class="main-area" tuiSurface appearance="floating">
 		<div class="document-detail">
 			<div class="toolbar">
-				<div class="left">
-					<button tuiButton size="s" appearance="secondary" iconStart="@tui.arrow-left" type="button" (click)="back()">{{ t('Document.Back') || '←' }}</button>
-					<h2 tuiTitle="m" class="doc-title">{{ document()?.title || originalFileName() || t('Document.DocumentTitleFallback') }}</h2>
-				</div>
+                                <div class="left">
+                                        <button tuiButton size="s" appearance="secondary" iconStart="@tui.arrow-left" type="button" (click)="back()">{{ t('Document.Back') || '←' }}</button>
+                                        <button tuiButton size="s" appearance="flat" iconStart="@tui.chevron-left" type="button" (click)="goToPrevious()" [disabled]="!canGoPrevious() || navLoading()">{{ t('Document.Previous') || '‹' }}</button>
+                                        <button tuiButton size="s" appearance="flat" iconStart="@tui.chevron-right" type="button" (click)="goToNext()" [disabled]="!canGoNext() || navLoading()">{{ t('Document.Next') || '›' }}</button>
+                                        <h2 tuiTitle="m" class="doc-title">{{ document()?.title || originalFileName() || t('Document.DocumentTitleFallback') }}</h2>
+                                </div>
 				<div class="actions" *ngIf="hasData()">
 					<!-- If archivePath exists show dropdown menu, else show direct download button -->
 					@if (document()?.archivePath) {

--- a/src/ArquivoMate2.Ui/src/app/services/document-navigation.service.ts
+++ b/src/ArquivoMate2.Ui/src/app/services/document-navigation.service.ts
@@ -1,0 +1,186 @@
+import { Injectable, computed, signal } from '@angular/core';
+import { DocumentsService } from '../client/services/documents.service';
+import { DocumentListDto } from '../client/models/document-list-dto';
+import { DocumentListItemDto } from '../client/models/document-list-item-dto';
+import { DocumentListDtoApiResponse } from '../client/models/document-list-dto-api-response';
+import { ApiDocumentsGet$Json$Params } from '../client/fn/documents/api-documents-get-json';
+import { Observable, of, throwError } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+
+export interface DocumentNavigationPage {
+  page: number;
+  items: readonly DocumentListItemDto[];
+  hasNext: boolean;
+  hasPrev: boolean;
+  totalCount: number | null;
+  pageCount: number | null;
+}
+
+interface NavigationContext {
+  pageSize: number;
+  search: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class DocumentNavigationService {
+  private readonly contextSignal = signal<NavigationContext | null>(null);
+  private readonly totalCountSignal = signal<number>(0);
+  private readonly pageCountSignal = signal<number>(0);
+  private readonly cacheVersionSignal = signal<number>(0);
+
+  private readonly cachedPages = new Map<number, DocumentNavigationPage>();
+
+  readonly hasContext = computed(() => !!this.contextSignal());
+  readonly pageSize = computed(() => this.contextSignal()?.pageSize ?? 0);
+  readonly search = computed(() => this.contextSignal()?.search ?? null);
+  readonly totalCount = computed(() => this.totalCountSignal());
+  readonly pageCount = computed(() => this.pageCountSignal());
+  readonly cacheVersion = computed(() => this.cacheVersionSignal());
+
+  constructor(private readonly api: DocumentsService) {}
+
+  prepare(options: { page: number; pageSize: number; search?: string | null; list?: DocumentListDto | null }): void {
+    const normalizedSearch = this.normalizeSearch(options.search);
+    this.updateContext({ pageSize: options.pageSize, search: normalizedSearch }, true);
+
+    const list = options.list;
+    if (list) {
+      const pageData = this.createPageFromList(list, options.page);
+      this.cachePage(pageData.page, pageData);
+    }
+  }
+
+  ensureContext(options: { pageSize: number; search?: string | null }): void {
+    const normalizedSearch = this.normalizeSearch(options.search);
+    const ctx = this.contextSignal();
+    if (!ctx || ctx.pageSize !== options.pageSize || ctx.search !== normalizedSearch) {
+      this.updateContext({ pageSize: options.pageSize, search: normalizedSearch }, true);
+    }
+  }
+
+  clear(): void {
+    this.contextSignal.set(null);
+    this.cachedPages.clear();
+    this.bumpCacheVersion();
+    this.totalCountSignal.set(0);
+    this.pageCountSignal.set(0);
+  }
+
+  getCachedPage(page: number): DocumentNavigationPage | null {
+    return this.cachedPages.get(page) ?? null;
+  }
+
+  getCachedPages(): DocumentNavigationPage[] {
+    return Array.from(this.cachedPages.values()).sort((a, b) => a.page - b.page);
+  }
+
+  ensurePage(page: number): Observable<DocumentNavigationPage> {
+    if (page < 1) {
+      return throwError(() => new Error('Page index must be positive.'));
+    }
+    const cached = this.cachedPages.get(page);
+    if (cached) {
+      return of({ ...cached, items: [...cached.items] });
+    }
+    const ctx = this.contextSignal();
+    if (!ctx) {
+      return throwError(() => new Error('Navigation context is not available.'));
+    }
+    const params: ApiDocumentsGet$Json$Params = {
+      Page: page,
+      PageSize: ctx.pageSize,
+      Search: ctx.search ?? undefined,
+    };
+    return this.api.apiDocumentsGet$Json(params).pipe(
+      map((resp: DocumentListDtoApiResponse) => {
+        if (!resp || resp.success === false) {
+          const message = resp?.message ?? 'Failed to load documents page.';
+          throw new Error(message);
+        }
+        const pageData = this.createPageFromList(resp.data, page);
+        return pageData;
+      }),
+      tap(pageData => {
+        this.cachePage(pageData.page, pageData);
+      })
+    );
+  }
+
+  private updateContext(ctx: NavigationContext, resetCache: boolean): void {
+    this.contextSignal.set(ctx);
+    if (resetCache) {
+      this.cachedPages.clear();
+      this.bumpCacheVersion();
+      this.totalCountSignal.set(0);
+      this.pageCountSignal.set(0);
+    }
+  }
+
+  private createPageFromList(list: DocumentListDto | null | undefined, page: number): DocumentNavigationPage {
+    const items = [...(list?.documents ?? [])];
+    const pageCount = list?.pageCount ?? null;
+    const hasNext = list?.hasNextPage ?? (pageCount != null ? page < pageCount : false);
+    const hasPrev = list?.hasPreviousPage ?? (page > 1);
+    const totalCount = list?.totalCount ?? null;
+
+    const pageData: DocumentNavigationPage = {
+      page,
+      items,
+      hasNext,
+      hasPrev,
+      totalCount,
+      pageCount,
+    };
+
+    this.applyTotals(pageData);
+
+    return pageData;
+  }
+
+  private cachePage(page: number, data: DocumentNavigationPage): void {
+    const copy: DocumentNavigationPage = {
+      page,
+      items: [...data.items],
+      hasNext: data.hasNext,
+      hasPrev: data.hasPrev,
+      totalCount: data.totalCount,
+      pageCount: data.pageCount,
+    };
+    this.cachedPages.set(page, copy);
+    this.bumpCacheVersion();
+    this.applyTotals(copy);
+  }
+
+  private applyTotals(page: DocumentNavigationPage): void {
+    if (typeof page.totalCount === 'number') {
+      this.totalCountSignal.set(page.totalCount);
+    }
+    if (typeof page.pageCount === 'number' && page.pageCount > 0) {
+      this.pageCountSignal.set(page.pageCount);
+    } else {
+      this.recomputePageCount();
+    }
+  }
+
+  private recomputePageCount(): void {
+    const total = this.totalCountSignal();
+    const ctx = this.contextSignal();
+    if (!ctx || ctx.pageSize <= 0 || total <= 0) {
+      if (total === 0) {
+        this.pageCountSignal.set(0);
+      }
+      return;
+    }
+    const computed = Math.max(1, Math.ceil(total / ctx.pageSize));
+    this.pageCountSignal.set(computed);
+  }
+
+  private bumpCacheVersion(): void {
+    this.cacheVersionSignal.update(v => v + 1);
+  }
+
+  private normalizeSearch(value: string | null | undefined): string | null {
+    const trimmed = (value ?? '').trim();
+    return trimmed.length ? trimmed : null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a document navigation service to manage paged list context and caching
- seed the navigation context when opening a document from the dashboard grid and add next/previous controls in the detail view
- localize the new navigation actions in all supported languages

## Testing
- npm run build *(fails: ng command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f5289074b083248b7f5945e0730f47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Previous and Next navigation buttons to the document viewer, enabling users to browse sequentially through documents in a list.
  * Extended localization support with new translations in German, English, and Russian for the navigation controls.

* **Improvements**
  * Improved navigation state persistence across different views to provide a seamless browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->